### PR TITLE
[Fix] 일주일 스트레칭 조회 쿼리 오류, 스트레칭 수정시 제목 중복 오류 해결 #86

### DIFF
--- a/controllers/stretching.js
+++ b/controllers/stretching.js
@@ -52,9 +52,9 @@ const updateStretching = async (req, res) => {
   try {
     const stretching = req.body;
     stretching.adminIdx = req.cookies.idx;
-
     const isTitleDuplicate = await stretchingService.findStretchingByTitle(stretching.title);
-    if (isTitleDuplicate.stretchingIdx !== stretching.stretchingIdx) {
+
+    if (isTitleDuplicate && isTitleDuplicate?.stretchingIdx !== stretching.stretchingIdx) {
       return res.status(CODE.DUPLICATE).json(form.fail(MSG.TITLE_ALREADY_EXIST));
     }
 

--- a/dao/week.js
+++ b/dao/week.js
@@ -171,7 +171,7 @@ const getWeek = async weekIdx => {
                                        FROM week_day_stretching as A
                                   LEFT JOIN stretching as B
                                          ON A.stretching_idx = B.stretching_idx
-                                      WHERE A.week_stretching_idx = 27
+                                      WHERE A.week_stretching_idx = ${weekIdx}
                                    ORDER BY week_day`;
 
     const [weekDayStretching] = await conn.query(getWeekDayStretchingSql);

--- a/middleware/validator/stretching.js
+++ b/middleware/validator/stretching.js
@@ -4,8 +4,8 @@ const createStretching = [
   body('title')
     .exists()
     .withMessage('title을(를) 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('title은 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .isLength({ min: 5, max: 50 })
+    .withMessage('title은 최소 5글자부터 최대 50글자까지 가능합니다.'),
   body('contents').exists().withMessage('contents을(를) 입력해주세요.'),
   body('mainBody')
     .exists()
@@ -44,8 +44,8 @@ const updateStretching = [
   body('title')
     .exists()
     .withMessage('title을(를) 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('title은 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .isLength({ min: 5, max: 50 })
+    .withMessage('title은 최소 5글자부터 최대 50글자까지 가능합니다.'),
   body('contents').exists().withMessage('contents을(를) 입력해주세요.'),
   body('mainBody')
     .exists()


### PR DESCRIPTION
## what is this PR?
- 일주일 스트레칭 조회시,` WHERE A.week_stretching_idx = 27` 로 하드코딩 되어 있는 부분 변수화
- 스트레칭 제목 수정 시, 중복되는 타이틀 있는 경우 조건에 추가

close #86 