### PR TITLE
[QA] #92 관리자 로그인, 계정 추가시, 입력값 validation

### DIFF
--- a/middleware/validator/admin.js
+++ b/middleware/validator/admin.js
@@ -4,18 +4,18 @@ const join = [
   body('id')
     .exists()
     .withMessage('아이디를 입력해주세요.')
-    .isLength({ min: 5, max: 10 })
-    .withMessage('아이디는 최소 5글자부터 최대 10글자까지 가능합니다.'),
+    .matches(/^[a-zA-Z0-9]{5,10}$/)
+    .withMessage('아이디는 영문, 숫자로 조합된 5자리 이상 10자리 이하로 입력해주세요.'),
   body('password')
-    .exists()
+    .notEmpty()
     .withMessage('비밀번호를 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .matches(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/)
+    .withMessage('비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.'),
   body('name')
     .exists()
     .withMessage('이름 입력해주세요.')
-    .isLength({ min: 2, max: 12 })
-    .withMessage('이름은 최소 2글자부터 최대 12글자까지 가능합니다.'),
+    .matches(/^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|]{2,8}$/)
+    .withMessage('이름은 한글, 영문, 숫자로 조합된 2자리 이상 8자리 이하로 입력해주세요.'),
   body('rank')
     .exists()
     .withMessage('등급을 입력해주세요.')
@@ -28,31 +28,31 @@ const login = [
   body('id')
     .exists()
     .withMessage('아이디를 입력해주세요.')
-    .isLength({ min: 5, max: 10 })
-    .withMessage('아이디는 최소 5글자부터 최대 10글자까지 가능합니다.'),
+    .matches(/^[a-zA-Z0-9]{5,10}$/)
+    .withMessage('아이디는 영문, 숫자로 조합된 5자리 이상 10자리 이하로 입력해주세요.'),
   body('password')
-    .exists()
+    .notEmpty()
     .withMessage('비밀번호를 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .matches(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/)
+    .withMessage('비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.'),
 ];
 
 const updatePassword = [
   body('beforePassword')
     .exists()
     .withMessage('기존 비밀번호를 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .matches(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/)
+    .withMessage('비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.'),
   body('newPassword')
     .exists()
     .withMessage('새로운 비밀번호를 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .matches(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/)
+    .withMessage('비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.'),
   body('confirmPassword')
     .exists()
     .withMessage('비밀번호 확인값을 입력해주세요.')
-    .isLength({ min: 5, max: 20 })
-    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .matches(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/)
+    .withMessage('비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.'),
 ];
 
 module.exports = {

--- a/middleware/validator/stretching.js
+++ b/middleware/validator/stretching.js
@@ -4,8 +4,8 @@ const createStretching = [
   body('title')
     .exists()
     .withMessage('title을(를) 입력해주세요.')
-    .isLength({ min: 5, max: 50 })
-    .withMessage('title은 최소 5글자부터 최대 50글자까지 가능합니다.'),
+    .isLength({ min: 2, max: 20 })
+    .withMessage('title은 최소 2글자부터 최대 20글자까지 가능합니다.'),
   body('contents').exists().withMessage('contents을(를) 입력해주세요.'),
   body('mainBody')
     .exists()

--- a/middleware/validator/week.js
+++ b/middleware/validator/week.js
@@ -5,7 +5,7 @@ const createWeek = [
     .exists()
     .withMessage('title을(를) 입력해주세요.')
     .isLength({ min: 2, max: 20 })
-    .withMessage('title은 최소 5글자부터 최대 20글자까지 가능합니다.'),
+    .withMessage('title은 최소 2글자부터 최대 20글자까지 가능합니다.'),
   body('week', 'week 는 숫자로만 이루어진 길이가 7인 배열이어야 합니다.')
     .isArray({ min: 7, max: 7 })
     .custom(v => v.every(e => e > 0)),


### PR DESCRIPTION
## Motivation 🤓
`FE`와 `BE`의 유저 입력값 `validation` 값이 맞지 않음.
<br>

## Key Changes 🔑
### 관리자 계정 등록시
- id : 아이디는 영문, 숫자로 조합된 5자리 이상 10자리 이하로 입력해주세요.
- password : 비밀번호는 영문, 숫자를 반드시 포함하여 8자리 이상 20자리 이하로 입력해주세요.
- name : 이름은 한글, 영문, 숫자로 조합된 2자리 이상 8자리 이하로 입력해주세요.

### 스트레칭, 일주일 스트레칭 제목
- title은 최소 2글자부터 최대 20글자까지 가능합니다.
<br>

## To Reviewers 🙋‍♀️
close #92 