### PR TITLE
[QA] #94 관리자, 회원 조회시, 삭제 안한 계정만 검색되도록 변경

### DIFF
--- a/dao/admin.js
+++ b/dao/admin.js
@@ -123,6 +123,7 @@ const getAdminsList = async () => {
                       , DATE_FORMAT(create_at,'%Y.%m.%d') AS 'createAt'
                       , DATE_FORMAT(delete_at,'%Y.%m.%d') AS 'deleteAt'
                    FROM admin
+                  WHERE delete_at IS NULL
                   ORDER BY create_at desc`;
 
     const [row] = await conn.query(sql);

--- a/index.js
+++ b/index.js
@@ -25,6 +25,5 @@ app.use(
 );
 
 app.use('/api', router);
-app.use('/uploads', express.static('uploads'));
 
 module.exports = app;


### PR DESCRIPTION
## Motivation 🤓
관리자 회원 조회시, 삭제된 계정도 같이 조회되었음.
<br>
관리자, 회원 조회시, 삭제 안한 계정만 검색되도록 변경
<br>

## Key Changes 🔑
- 회원 검색 쿼리에 `WHERE delete_at IS NULL` 추가
- `DB admin 테이블`의 delete_at 칼럼이 `default 값`으로 `'null'` 문자열을 넣고 있었음. `NULL`로 변경
<br>

## To Reviewers 🙋‍♀️
close #94 