### PR TITLE
[QA] #96 READ ONLY 계정 추가

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -68,7 +68,22 @@ const checkSuperAdmin = async (req, res, next) => {
   next();
 };
 
+const checkReadOnlyAdmin = async (req, res, next) => {
+  try {
+    const admin = await adminService.findAdminByIdx(req.cookies.idx);
+    if (admin.rank===2) {
+      return res.status(CODE.UNAUTHORIZED).json(form.fail(MSG.UNAUTHORIZED));
+    }
+  } catch (err) {
+    console.error(`===Auth Middleware Error > ${err}===`);
+    return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
+  }
+
+  next();
+};
+
 module.exports = {
   checkToken,
   checkSuperAdmin,
+  checkReadOnlyAdmin
 };

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -7,12 +7,21 @@ const commonValidator = require('../middleware/validator/common');
 const validatorError = require('../middleware/validatorError');
 const auth = require('../middleware/auth');
 
-router.post('/join', auth.checkToken, auth.checkSuperAdmin, validator.join, validatorError.err, adminCtrl.join);
+router.post(
+  '/join',
+  auth.checkToken,
+  auth.checkSuperAdmin,
+  auth.checkReadOnlyAdmin,
+  validator.join,
+  validatorError.err,
+  adminCtrl.join
+);
 router.post('/login', validator.login, validatorError.err, adminCtrl.login);
 router.post('/logout', auth.checkToken, adminCtrl.logout);
 router.patch(
   '/password/:adminIdx',
   auth.checkToken,
+  auth.checkReadOnlyAdmin,
   validator.updatePassword,
   validatorError.err,
   adminCtrl.updatePassword

--- a/routes/stretching.js
+++ b/routes/stretching.js
@@ -7,10 +7,31 @@ const validator = require('../middleware/validator/stretching');
 const commonValidator = require('../middleware/validator/common');
 const validatorError = require('../middleware/validatorError');
 
-router.post('/', auth.checkToken, validator.createStretching, validatorError.err, stretchingCtrl.createStretching);
-router.delete('/:idx', auth.checkToken, commonValidator.checkParamIdx, validatorError.err, stretchingCtrl.deleteStretching);
+router.post(
+  '/',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  validator.createStretching,
+  validatorError.err,
+  stretchingCtrl.createStretching
+);
+router.delete(
+  '/:idx',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  commonValidator.checkParamIdx,
+  validatorError.err,
+  stretchingCtrl.deleteStretching
+);
 router.get('/:idx', auth.checkToken, commonValidator.checkParamIdx, validatorError.err, stretchingCtrl.getStretching);
-router.put('/', auth.checkToken, validator.updateStretching, validatorError.err, stretchingCtrl.updateStretching);
+router.put(
+  '/',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  validator.updateStretching,
+  validatorError.err,
+  stretchingCtrl.updateStretching
+);
 router.get('/', auth.checkToken, validator.getStretchings, validatorError.err, stretchingCtrl.getStretchings);
 
 module.exports = router;

--- a/routes/week.js
+++ b/routes/week.js
@@ -8,12 +8,47 @@ const commonValidator = require('../middleware/validator/common');
 const validatorError = require('../middleware/validatorError');
 
 router.get('/', auth.checkToken, weekCtrl.getWeeks);
-router.post('/', auth.checkToken, validator.createWeek, validatorError.err, weekCtrl.createWeek);
-router.delete('/:idx', auth.checkToken, commonValidator.checkParamIdx, validatorError.err, weekCtrl.deleteWeek);
-router.put('/', auth.checkToken, validator.updateWeek, validatorError.err, weekCtrl.updateWeek);
+router.post(
+  '/',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  validator.createWeek,
+  validatorError.err,
+  weekCtrl.createWeek
+);
+router.delete(
+  '/:idx',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  commonValidator.checkParamIdx,
+  validatorError.err,
+  weekCtrl.deleteWeek
+);
+router.put(
+  '/',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  validator.updateWeek,
+  validatorError.err,
+  weekCtrl.updateWeek
+);
 router.get('/:idx', auth.checkToken, commonValidator.checkParamIdx, validatorError.err, weekCtrl.getWeek);
-router.patch('/expose', auth.checkToken, validator.checkBodyIdx, validatorError.err, weekCtrl.updateExposeWeek);
-router.delete('/expose/:idx', auth.checkToken, commonValidator.checkParamIdx, validatorError.err, weekCtrl.cancelExposeWeek);
+router.patch(
+  '/expose',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  validator.checkBodyIdx,
+  validatorError.err,
+  weekCtrl.updateExposeWeek
+);
+router.delete(
+  '/expose/:idx',
+  auth.checkToken,
+  auth.checkReadOnlyAdmin,
+  commonValidator.checkParamIdx,
+  validatorError.err,
+  weekCtrl.cancelExposeWeek
+);
 router.get('/expose/stretchings', auth.checkToken, weekCtrl.getExposeWeek);
 
 module.exports = router;

--- a/service/admin.js
+++ b/service/admin.js
@@ -20,7 +20,7 @@ const join = async joinUser => {
 const login = async ({ id, password }) => {
   try {
     const admin = await adminDao.findAdminById(id);
- 
+
     if (!admin || admin.deleteAt) {
       return CODE.BAD_REQUEST;
     }


### PR DESCRIPTION
## Motivation 🤓
면접관용 `READ ONLY` 계정을 추가하고자 함.

`admin` `role===2` 인 계정은, `READ` 만 가능함
<br>

## Key Changes 🔑
`checkReadOnlyAdmin` 미들웨어를 추가하여, `CREATE/UPDATE/DELETE` 작업시, 권한 차단
- BE : CRUD 중 CUD api 요청시, 권한 차단
- FE : CRUD 중 R 요청시, 문자열 검열
<br>

## To Reviewers 🙋‍♀️
![image](https://user-images.githubusercontent.com/57309520/168520732-e09a0f92-3dcc-4263-8ebe-05e62257315d.png)
![image](https://user-images.githubusercontent.com/57309520/168520774-fbbc20a9-9994-46a0-9487-ed8d365818c0.png)

close #96 