### PR TITLE
Bugfix/98 토큰 재발급 에러

### DIFF
--- a/bin/www.js
+++ b/bin/www.js
@@ -3,4 +3,4 @@ require('dotenv').config();
 
 const port = process.env.PORT || 8000;
 
-app.listen(port, () => console.log(`Dev Server listening on port ${port}!`));
+app.listen(port, () => console.log(`🚀 Dev Server listening on port ${port}!`));

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -35,6 +35,7 @@ const checkToken = async (req, res, next) => {
 
     res.cookie('accessToken', newAccessToken);
     req.cookies.accessToken = newAccessToken;
+    req.cookies.userIdx = refreshToken.idx;
 
     next();
   } else if (refreshToken === TOKEN_EXPIRED) {
@@ -45,6 +46,7 @@ const checkToken = async (req, res, next) => {
     redis.set(accessToken.idx, newRefreshToken);
     res.cookie('refreshToken', newRefreshToken);
     req.cookies.refreshToken = newRefreshToken;
+    req.cookies.userIdx = accessToken.idx;
 
     next();
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movester_server_dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Motivation 🤓
토큰 재발급시, 재발급만 해주고 요청사항은 하지 못하고 에러 발생
ex) 출석도장 조회시, 만료된 토큰은 재발급 해주고, 출석도장 조회는 실패
<br>

## Key Changes 🔑
middleware > auth.js 에서
토큰 재발급 해주는 경우, 재발급만 해주고 `req.cookies.userIdx = userIdx` 를 통해,
`Controller` 에 `userIdx` 값을 주고 있지 않았음.
해당 구문 추가하여 해결
<br>

## To Reviewers 🙋‍♀️
.

close #98